### PR TITLE
Add language selector for jokeapi to config

### DIFF
--- a/custom_components/ha_jokes/__init__.py
+++ b/custom_components/ha_jokes/__init__.py
@@ -91,6 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         refresh_interval,
         enabled_providers,
         jokeapi_language,
+        entry,
     )
     
     # Fetch initial data - this can raise ConfigEntryNotReady

--- a/custom_components/ha_jokes/__init__.py
+++ b/custom_components/ha_jokes/__init__.py
@@ -11,11 +11,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import (
-    DOMAIN,
-    CONF_REFRESH_INTERVAL,
+    CONF_JOKEAPI_LANGUAGE,
     CONF_PROVIDERS,
-    DEFAULT_REFRESH_INTERVAL,
+    CONF_REFRESH_INTERVAL,
+    DEFAULT_JOKEAPI_LANGUAGE,
     DEFAULT_PROVIDERS,
+    DEFAULT_REFRESH_INTERVAL,
+    DOMAIN,
     VERSION,
 )
 from .sensor import JokesDataUpdateCoordinator
@@ -79,9 +81,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     enabled_providers = entry.options.get(
         CONF_PROVIDERS, DEFAULT_PROVIDERS
     )
+    jokeapi_language = entry.options.get(
+        CONF_JOKEAPI_LANGUAGE, DEFAULT_JOKEAPI_LANGUAGE
+    )
     
     # Create coordinator
-    coordinator = JokesDataUpdateCoordinator(hass, refresh_interval, enabled_providers)
+    coordinator = JokesDataUpdateCoordinator(
+        hass,
+        refresh_interval,
+        enabled_providers,
+        jokeapi_language,
+    )
     
     # Fetch initial data - this can raise ConfigEntryNotReady
     try:

--- a/custom_components/ha_jokes/config_flow.py
+++ b/custom_components/ha_jokes/config_flow.py
@@ -10,13 +10,17 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import selector
 
 from .const import (
+    CONF_JOKEAPI_LANGUAGE,
     CONF_PROVIDERS,
     CONF_REFRESH_INTERVAL,
+    DEFAULT_JOKEAPI_LANGUAGE,
     DEFAULT_PROVIDERS,
     DEFAULT_REFRESH_INTERVAL,
     DOMAIN,
+    JOKEAPI_LANGUAGE_OPTIONS,
     MAX_REFRESH_INTERVAL,
     MIN_REFRESH_INTERVAL,
     NAME,
@@ -51,6 +55,10 @@ class JokesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             providers = user_input.get(CONF_PROVIDERS, [])
             if not providers:
                 errors[CONF_PROVIDERS] = "no_providers_selected"
+
+            jokeapi_language = user_input.get(
+                CONF_JOKEAPI_LANGUAGE, DEFAULT_JOKEAPI_LANGUAGE
+            )
             
             if not errors:
                 # Create the config entry
@@ -60,6 +68,7 @@ class JokesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     options={
                         CONF_REFRESH_INTERVAL: refresh_interval,
                         CONF_PROVIDERS: providers,
+                        CONF_JOKEAPI_LANGUAGE: jokeapi_language,
                     },
                 )
 
@@ -78,6 +87,18 @@ class JokesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     PROVIDER_GEEKJOKES: "Geek Jokes (⚠️ not family-friendly)",
                     PROVIDER_YOMAMA: "Yo Mama Jokes (⚠️ not family-friendly)",
                 }),
+                vol.Optional(
+                    CONF_JOKEAPI_LANGUAGE,
+                    default=DEFAULT_JOKEAPI_LANGUAGE,
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(value=code, label=label)
+                            for code, label in JOKEAPI_LANGUAGE_OPTIONS.items()
+                        ],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
             }
         )
 
@@ -120,9 +141,18 @@ class JokesOptionsFlow(config_entries.OptionsFlow):
             providers = user_input.get(CONF_PROVIDERS, [])
             if not providers:
                 errors[CONF_PROVIDERS] = "no_providers_selected"
-            
+
+            jokeapi_language = user_input.get(
+                CONF_JOKEAPI_LANGUAGE, DEFAULT_JOKEAPI_LANGUAGE
+            )
             if not errors:
-                return self.async_create_entry(title="", data=user_input)
+                return self.async_create_entry(
+                    title="",
+                    data={
+                        **user_input,
+                        CONF_JOKEAPI_LANGUAGE: jokeapi_language,
+                    },
+                )
 
         # Get current options or defaults
         current_refresh_interval = self._config_entry.options.get(
@@ -130,6 +160,9 @@ class JokesOptionsFlow(config_entries.OptionsFlow):
         )
         current_providers = self._config_entry.options.get(
             CONF_PROVIDERS, DEFAULT_PROVIDERS
+        )
+        current_jokeapi_language = self._config_entry.options.get(
+            CONF_JOKEAPI_LANGUAGE, DEFAULT_JOKEAPI_LANGUAGE
         )
 
         # Schema for the options form
@@ -147,6 +180,18 @@ class JokesOptionsFlow(config_entries.OptionsFlow):
                     PROVIDER_GEEKJOKES: "Geek Jokes (⚠️ not family-friendly)",
                     PROVIDER_YOMAMA: "Yo Mama Jokes (⚠️ not family-friendly)",
                 }),
+                vol.Optional(
+                    CONF_JOKEAPI_LANGUAGE,
+                    default=current_jokeapi_language,
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            selector.SelectOptionDict(value=code, label=label)
+                            for code, label in JOKEAPI_LANGUAGE_OPTIONS.items()
+                        ],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
             }
         )
 

--- a/custom_components/ha_jokes/const.py
+++ b/custom_components/ha_jokes/const.py
@@ -56,6 +56,7 @@ SENSOR_ICON = "mdi:emoticon-happy-outline"
 # Configuration Keys
 CONF_REFRESH_INTERVAL = "refresh_interval"
 CONF_PROVIDERS = "providers"
+CONF_JOKEAPI_LANGUAGE = "jokeapi_language"
 
 # Attributes
 ATTR_JOKE = "joke"
@@ -81,6 +82,15 @@ DEFAULT_PROVIDERS = [
     PROVIDER_JOKEAPI,
     PROVIDER_OFFICIAL,
 ]
+DEFAULT_JOKEAPI_LANGUAGE = "en"
+JOKEAPI_LANGUAGE_OPTIONS = {
+    "cs": "Czech",
+    "de": "German",
+    "en": "English",
+    "es": "Spanish",
+    "fr": "French",
+    "pt": "Portuguese",
+}
 
 # States
 STATE_OK = "OK"

--- a/custom_components/ha_jokes/sensor.py
+++ b/custom_components/ha_jokes/sensor.py
@@ -79,7 +79,6 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _build_provider_configs(self) -> list[dict[str, Any]]:
         """Build provider configurations."""
-        jokeapi_url = f"{API_URL_JOKEAPI}&lang={self._jokeapi_language}"
         return [
             {
                 "name": PROVIDER_ICANHAZDADJOKE,
@@ -89,7 +88,7 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
             },
             {
                 "name": PROVIDER_JOKEAPI,
-                "url": jokeapi_url,
+                "url": f"{API_URL_JOKEAPI}&lang={self._jokeapi_language}",
                 "headers": API_HEADERS_JOKEAPI,
                 "parser": self._parse_jokeapi,
             },

--- a/custom_components/ha_jokes/sensor.py
+++ b/custom_components/ha_jokes/sensor.py
@@ -314,7 +314,9 @@ class JokesSensor(CoordinatorEntity, SensorEntity):
             self._config_entry.add_update_listener(self._async_update_options)
         )
 
-    async def _async_update_options(self, config_entry: ConfigEntry) -> None:
+    async def _async_update_options(
+        self, hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> None:
         """Update options."""
         refresh_interval = config_entry.options.get(
             CONF_REFRESH_INTERVAL, DEFAULT_REFRESH_INTERVAL

--- a/custom_components/ha_jokes/sensor.py
+++ b/custom_components/ha_jokes/sensor.py
@@ -119,6 +119,7 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
         refresh_interval: int,
         enabled_providers: list[str],
         jokeapi_language: str | None = None,
+        config_entry: ConfigEntry | None = None,
     ) -> None:
         """Initialize."""
         self.platforms = []
@@ -134,6 +135,7 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(minutes=refresh_interval),
+            config_entry=config_entry,
         )
 
     def _parse_icanhazdadjoke(self, data: dict) -> dict[str, Any]:

--- a/custom_components/ha_jokes/sensor.py
+++ b/custom_components/ha_jokes/sensor.py
@@ -37,8 +37,10 @@ from .const import (
     ATTR_LAST_UPDATED,
     ATTR_REFRESH_INTERVAL,
     ATTR_SOURCE,
+    CONF_JOKEAPI_LANGUAGE,
     CONF_PROVIDERS,
     CONF_REFRESH_INTERVAL,
+    DEFAULT_JOKEAPI_LANGUAGE,
     DEFAULT_PROVIDERS,
     DEFAULT_REFRESH_INTERVAL,
     DOMAIN,
@@ -77,6 +79,7 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _build_provider_configs(self) -> list[dict[str, Any]]:
         """Build provider configurations."""
+        jokeapi_url = f"{API_URL_JOKEAPI}&lang={self._jokeapi_language}"
         return [
             {
                 "name": PROVIDER_ICANHAZDADJOKE,
@@ -86,7 +89,7 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
             },
             {
                 "name": PROVIDER_JOKEAPI,
-                "url": API_URL_JOKEAPI,
+                "url": jokeapi_url,
                 "headers": API_HEADERS_JOKEAPI,
                 "parser": self._parse_jokeapi,
             },
@@ -110,11 +113,18 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
             },
         ]
 
-    def __init__(self, hass: HomeAssistant, refresh_interval: int, enabled_providers: list[str]) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        refresh_interval: int,
+        enabled_providers: list[str],
+        jokeapi_language: str | None = None,
+    ) -> None:
         """Initialize."""
         self.platforms = []
         self._refresh_interval = refresh_interval
         self._enabled_providers = enabled_providers if enabled_providers else DEFAULT_PROVIDERS
+        self._jokeapi_language = jokeapi_language or DEFAULT_JOKEAPI_LANGUAGE
         
         # Filter to only enabled providers
         self._providers = [p for p in self._build_provider_configs() if p["name"] in self._enabled_providers]
@@ -253,6 +263,11 @@ class JokesDataUpdateCoordinator(DataUpdateCoordinator):
         # Rebuild providers list using centralized configuration
         self._providers = [p for p in self._build_provider_configs() if p["name"] in self._enabled_providers]
 
+    def update_jokeapi_language(self, jokeapi_language: str) -> None:
+        """Update the JokeAPI language setting."""
+        self._jokeapi_language = jokeapi_language or DEFAULT_JOKEAPI_LANGUAGE
+        self._providers = [p for p in self._build_provider_configs() if p["name"] in self._enabled_providers]
+
 
 class JokesSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Jokes sensor."""
@@ -307,8 +322,12 @@ class JokesSensor(CoordinatorEntity, SensorEntity):
         enabled_providers = config_entry.options.get(
             CONF_PROVIDERS, DEFAULT_PROVIDERS
         )
+        jokeapi_language = config_entry.options.get(
+            CONF_JOKEAPI_LANGUAGE, DEFAULT_JOKEAPI_LANGUAGE
+        )
         self.coordinator.update_refresh_interval(refresh_interval)
         self.coordinator.update_enabled_providers(enabled_providers)
+        self.coordinator.update_jokeapi_language(jokeapi_language)
         await self.coordinator.async_request_refresh()
 
 

--- a/custom_components/ha_jokes/strings.json
+++ b/custom_components/ha_jokes/strings.json
@@ -6,10 +6,12 @@
         "description": "Configure your Jokes integration",
         "data": {
           "refresh_interval": "Refresh interval (minutes)",
-          "providers": "Joke providers"
+          "providers": "Joke providers",
+          "jokeapi_language": "JokeAPI language"
         },
         "data_description": {
-          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default."
+          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default.",
+          "jokeapi_language": "Choose the language to request from JokeAPI when that provider is enabled."
         }
       }
     },
@@ -25,10 +27,12 @@
         "description": "Configure Jokes options",
         "data": {
           "refresh_interval": "Refresh interval (minutes)",
-          "providers": "Joke providers"
+          "providers": "Joke providers",
+          "jokeapi_language": "JokeAPI language"
         },
         "data_description": {
-          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default."
+          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default.",
+          "jokeapi_language": "Choose the language to request from JokeAPI when that provider is enabled."
         }
       }
     },

--- a/custom_components/ha_jokes/translations/en.json
+++ b/custom_components/ha_jokes/translations/en.json
@@ -6,10 +6,12 @@
         "description": "Configure your Jokes integration",
         "data": {
           "refresh_interval": "Refresh interval (minutes)",
-          "providers": "Joke providers"
+          "providers": "Joke providers",
+          "jokeapi_language": "JokeAPI language"
         },
         "data_description": {
-          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default."
+          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default.",
+          "jokeapi_language": "Choose the language to request from JokeAPI when that provider is enabled."
         }
       }
     },
@@ -25,10 +27,12 @@
         "description": "Configure Jokes options",
         "data": {
           "refresh_interval": "Refresh interval (minutes)",
-          "providers": "Joke providers"
+          "providers": "Joke providers",
+          "jokeapi_language": "JokeAPI language"
         },
         "data_description": {
-          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default."
+          "providers": "Select which joke sources to use. Note: \"Geek Jokes\" (mostly Chuck Norris / crude) and \"Yo Mama Jokes\" (roast humour) serve unfiltered adult content and are not family-friendly — both are off by default.",
+          "jokeapi_language": "Choose the language to request from JokeAPI when that provider is enabled."
         }
       }
     },


### PR DESCRIPTION
Hi,

I want to use this in my voice assistant but the api often returns jokes that only land in a specific language. My language is german, so the translated english jokes wouldn't land and my kids would not have fun with this :)

So I implemented a language selector for the jokeapi provider. It defaults to english, so upgrading should work fine (it did in my install) and respects the language in the request.

Thanks for the addon :)